### PR TITLE
feat: 카드 이미지 URL 백엔드 관리 및 프론트 표시 기능

### DIFF
--- a/Backend-main/cards/management/commands/sync_card_images.py
+++ b/Backend-main/cards/management/commands/sync_card_images.py
@@ -1,0 +1,43 @@
+import csv
+from django.core.management.base import BaseCommand
+from cards.models import Card
+
+
+class Command(BaseCommand):
+    help = 'card_gorilla_list.csv에서 카드이름과 이미지URL을 매칭해 DB의 card_image_url을 업데이트합니다.'
+
+    def handle(self, *args, **options):
+        file_path = '/app/card_gorilla_list.csv'
+        updated_count = 0
+        not_found_count = 0
+        
+        try:
+            with open(file_path, 'r', encoding='utf-8-sig') as f:
+                reader = csv.DictReader(f)
+                
+                for row in reader:
+                    card_name = row.get('카드명', '').strip()
+                    image_url = row.get('이미지URL', '').strip()
+                    
+                    if not card_name or not image_url:
+                        continue
+                    
+                    # 카드명으로 DB에서 찾기
+                    try:
+                        card = Card.objects.get(card_name=card_name)
+                        card.card_image_url = image_url
+                        card.save()
+                        updated_count += 1
+                        self.stdout.write(f"✓ {card_name} - 이미지 URL 업데이트")
+                    except Card.DoesNotExist:
+                        not_found_count += 1
+                        self.stdout.write(self.style.WARNING(f"✗ {card_name} - DB에 없음"))
+                
+                self.stdout.write(self.style.SUCCESS(
+                    f"\n완료: {updated_count}개 업데이트, {not_found_count}개 미매칭"
+                ))
+                
+        except FileNotFoundError:
+            self.stdout.write(self.style.ERROR(f"파일을 찾을 수 없습니다: {file_path}"))
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"에러: {e}"))

--- a/Backend-main/cards/serializers.py
+++ b/Backend-main/cards/serializers.py
@@ -4,11 +4,21 @@ from .models import Card, CardBenefit
 
 # 카드 시리얼라이저
 class CardSerializer(serializers.ModelSerializer):
-    image = serializers.ReadOnlyField(source='card_image_url') # 카드 이미지 URL 매핑
+    image = serializers.SerializerMethodField()  # 절대 URL 변환용
     
     class Meta:
         model = Card 
         fields = ['card_id', 'card_name', 'image']
+
+    def get_image(self, obj):
+        """card_image_url이 상대경로일 때도 절대경로로 반환"""
+        request = self.context.get('request')
+        url = obj.card_image_url
+        if not url:
+            return None
+        if request and url.startswith('/'):
+            return request.build_absolute_uri(url)
+        return url
 
 # 내 카드 목록용 시리얼라이저 (카드 번호 포함)
 class UserCardListSerializer(serializers.Serializer):
@@ -22,7 +32,7 @@ class UserCardListSerializer(serializers.Serializer):
 
 # 추천 카드 시리얼라이저
 class RecommendedCardSerializer(serializers.ModelSerializer):
-    image = serializers.ReadOnlyField(source='card_image_url') # 카드 이미지 URL 매핑
+    image = serializers.SerializerMethodField()  # 절대 URL 변환용
     benefit_summary = serializers.ReadOnlyField(source='benefit_cap_summary') # 혜택 요약 매핑
     annual_fee = serializers.ReadOnlyField(source='annual_fee_domestic') # 국내 연회비 매핑
     annual_fee_international = serializers.ReadOnlyField(source='annual_fee_overseas') # 해외 연회비 매핑
@@ -31,6 +41,15 @@ class RecommendedCardSerializer(serializers.ModelSerializer):
         model = Card
         fields = ['card_id', 'card_name', 'annual_fee', 'annual_fee_international', 
                   'company', 'image', 'benefit_summary']
+
+    def get_image(self, obj):
+        request = self.context.get('request')
+        url = obj.card_image_url
+        if not url:
+            return None
+        if request and url.startswith('/'):
+            return request.build_absolute_uri(url)
+        return url
         
 
 

--- a/Backend-main/users/views.py
+++ b/Backend-main/users/views.py
@@ -3,7 +3,8 @@ from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
 from drf_spectacular.utils import extend_schema, OpenApiExample
-from .models import User
+from .models import User, UserCard
+from cards.models import Card
 
 class SignUpView(APIView): # 회원가입 뷰
     @extend_schema(
@@ -53,6 +54,18 @@ class SignUpView(APIView): # 회원가입 뷰
             email=email
         )
         """
+
+        # [테스트 기능] 신규 사용자에게 인기 카드 3개 자동 등록
+        try:
+            popular_cards = Card.objects.filter(card_image_url__isnull=False).exclude(card_image_url='')[:3]
+            for card in popular_cards:
+                UserCard.objects.create(
+                    user=user,
+                    card=card,
+                    card_number=f"****{str(card.card_id).zfill(4)}"  # 더미 카드 번호
+                )
+        except Exception as e:
+            pass  # 카드 등록 실패해도 회원가입은 진행
 
         return Response({"message": "회원가입 성공", "result": {"user_id": user.user_id}}, status=status.HTTP_201_CREATED)
 

--- a/CARD_IMAGE_FEATURE_README.md
+++ b/CARD_IMAGE_FEATURE_README.md
@@ -1,0 +1,31 @@
+# 카드 이미지 기능
+
+## 실행 방법
+
+1. Django 마이그레이션
+```bash
+python manage.py migrate
+```
+
+2. 카드 데이터 & 이미지 URL 로드
+```bash
+python manage.py load_cards
+python manage.py sync_card_images
+```
+
+3. 테스트 계정으로 로그인
+- 전화번호: `01012345678`
+- 비밀번호: `test1234`
+
+4. 카드 탭에서 이미지 확인 ✓
+
+## 주요 변경 파일
+
+**Backend**: `cards/serializers.py`, `cards/management/commands/sync_card_images.py`, `users/views.py`
+
+**Frontend**: `lib/services/card_service.dart`, `lib/screens/cards/card_analysis_page.dart`, `lib/screens/cards/card_detail_page.dart`
+
+---
+
+이미지는 CSV에서 로드되어 DB에 저장되고, API를 통해 프론트에서 표시됩니다.
+

--- a/Frontend/lib/models/card.dart
+++ b/Frontend/lib/models/card.dart
@@ -1,10 +1,12 @@
+// [설명] 신용카드 정보를 담는 모델 클래스
+// [용도] 백엔드 API에서 받아온 카드 정보를 Flutter 앱에서 사용하기 위한 객체로 변환
 class CreditCard {
-  final int id;
-  final String name;
-  final String company;
-  final int annualFee;
-  final String? imageUrl;
-  final List<CardBenefit> benefits;
+  final int id; // [설명] 카드 고유 ID (백엔드 card_id)
+  final String name; // [설명] 카드 이름 (예: "신한Deep Dream 카드")
+  final String company; // [설명] 카드 발급사 (예: "신한카드", "KB국민카드")
+  final int annualFee; // [설명] 연회비 (국내)
+  final String? imageUrl; // [설명] 카드 이미지 URL (백엔드에서 제공, null 가능)
+  final List<CardBenefit> benefits; // [설명] 카드 혜택 리스트
 
   CreditCard({
     required this.id,
@@ -15,14 +17,29 @@ class CreditCard {
     this.benefits = const [],
   });
 
+  // [설명] JSON 데이터를 CreditCard 객체로 변환하는 팩토리 생성자
+  // [백엔드 API 응답 필드]
+  //   - card_id -> id
+  //   - card_name -> name
+  //   - company -> company
+  //   - annual_fee -> annualFee
+  //   - image -> imageUrl (백엔드 serializer에서 card_image_url을 'image'로 매핑)
   factory CreditCard.fromJson(Map<String, dynamic> json) {
     return CreditCard(
-      id: json['id'],
-      name: json['name'],
-      company: json['company'],
-      annualFee: json['annual_fee'],
-      imageUrl: json['image_url'],
-      benefits: (json['benefits'] as List?)
+      // [설명] 백엔드 응답의 'card_id' 필드를 id로 매핑
+      id: json['card_id'] ?? json['id'] ?? 0,
+      // [설명] 백엔드 응답의 'card_name' 필드를 name으로 매핑
+      name: json['card_name'] ?? json['name'] ?? '',
+      // [설명] 카드 발급사 정보
+      company: json['company'] ?? '',
+      // [설명] 연회비 정보 (기본값 0)
+      annualFee: json['annual_fee'] ?? 0,
+      // [중요] 백엔드에서 'image' 필드로 card_image_url을 반환하므로 'image'에서 가져옴
+      // 백엔드 CardSerializer에서 card_image_url -> 'image'로 매핑됨
+      imageUrl: json['image'] ?? json['card_image_url'] ?? json['image_url'],
+      // [설명] 혜택 리스트 파싱 (없으면 빈 리스트)
+      benefits:
+          (json['benefits'] as List?)
               ?.map((b) => CardBenefit.fromJson(b))
               .toList() ??
           [],

--- a/Frontend/lib/screens/cards/card_analysis_page.dart
+++ b/Frontend/lib/screens/cards/card_analysis_page.dart
@@ -1,18 +1,98 @@
+// [설명] 카드 분석 화면 - 사용자가 등록한 카드와 추천 카드 표시
+// [수정사항] 백엔드 API에서 카드 데이터와 이미지 URL을 받아와서 표시하도록 변경
 import 'package:flutter/material.dart';
-import 'package:my_app/screens/cards/card_detail_page.dart';
+import 'package:my_app/services/card_service.dart'; // [추가] 카드 서비스 import
+import 'package:my_app/models/card.dart'; // [추가] 카드 모델 import
+import 'package:my_app/widgets/card_image.dart'; // [추가] 카드 이미지 위젯 import
+import 'package:my_app/screens/cards/card_detail_page.dart'; // [추가] 카드 상세 페이지 import
 
-class CardAnalysisPage extends StatelessWidget {
+// [수정] StatelessWidget에서 StatefulWidget으로 변경 (API 호출을 위해)
+class CardAnalysisPage extends StatefulWidget {
   const CardAnalysisPage({super.key});
 
-  static final List<WalletCard> _cards = [
-    WalletCard(imagePath: 'assets/cards/card1.png', color: Color(0xFFECECEC), label: '신한 5699', bankName: '신한카드', maskedNumber: '**** 5699'),
-    WalletCard(imagePath: 'assets/cards/card2.png', color: Color(0xFFEFF66A), label: '토스 5289', bankName: '토스뱅크', maskedNumber: '**** 5289'),
-    WalletCard(imagePath: 'assets/cards/card3.png', color: Color(0xFFF2F2F4), label: '비씨 7892', bankName: '비씨카드', maskedNumber: '**** 7892'),
-    WalletCard(imagePath: 'assets/cards/card4.png', color: Color(0xFFBFCFE6), label: '국민 2095', bankName: 'KB국민카드', maskedNumber: '**** 2095'),
-  ];
+  @override
+  State<CardAnalysisPage> createState() => _CardAnalysisPageState();
+}
+
+class _CardAnalysisPageState extends State<CardAnalysisPage> {
+  // [추가] 카드 서비스 인스턴스 생성
+  final CardService _cardService = CardService();
+
+  // [추가] 사용자 카드 리스트 (백엔드에서 가져옴)
+  List<CreditCard> _userCards = [];
+
+  // [추가] 추천 카드 리스트 (백엔드에서 가져옴)
+  List<CreditCard> _recommendedCards = [];
+
+  // [추가] 로딩 상태 관리
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    // [추가] 화면 초기화 시 카드 데이터 로드
+    _loadCards();
+  }
+
+  // [추가] 백엔드에서 카드 데이터를 가져오는 메서드
+  Future<void> _loadCards() async {
+    try {
+      setState(() {
+        _isLoading = true;
+      });
+
+      // [설명] 백엔드 API를 호출하여 사용자 카드와 추천 카드 동시에 가져오기
+      final results = await Future.wait([
+        _cardService.getMyCards(), // 사용자가 등록한 카드 목록
+        _cardService.getRecommendedCards(), // 추천 카드 목록
+      ]);
+
+      setState(() {
+        _userCards = results[0]; // 사용자 카드
+        _recommendedCards = results[1]; // 추천 카드
+        _isLoading = false;
+      });
+    } catch (e) {
+      // [설명] API 호출 실패 시 에러 처리
+      print('카드 로드 에러: $e'); // 디버깅용 로그
+      setState(() {
+        _isLoading = false;
+      });
+
+      // [설명] 에러 발생 시 사용자에게 안내
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('카드 정보를 불러오지 못했습니다: ${e.toString()}')),
+        );
+      }
+    }
+  }
+
+  // [추가] 더미 데이터 로드 (백엔드 연결 실패 시 폴백용)
+  void _loadDummyCards() {
+    setState(() {
+      // 더미 카드 데이터는 원래 코드의 _cards 사용
+      _userCards = []; // 실제로는 더미 데이터를 여기에 추가 가능
+      _recommendedCards = [];
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
+    // [설명] 로딩 중일 때 로딩 인디케이터 표시
+    if (_isLoading) {
+      return Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => Navigator.of(context).maybePop(),
+          ),
+          centerTitle: true,
+        ),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         // Title intentionally left blank per UI request
@@ -30,29 +110,40 @@ class CardAnalysisPage extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // Wallet stack (full width inside padding)
+                // [수정] 백엔드 데이터 _userCards를 사용하여 카드 스택 표시
                 SizedBox(
                   width: double.infinity,
                   height: 520,
-                  child: Stack(
-                    clipBehavior: Clip.none,
-                    children: List.generate(_cards.length, (i) {
-                      final card = _cards[i];
-                      // Keep all visible cards the same scale/size.
-                      final offset = i * 40.0; // tighten overlap so more cards are visible
-                      final scale = 1.0;
-                      return Positioned(
-                        top: offset,
-                        left: 0,
-                        right: 0,
-                        child: Transform.scale(
-                          scale: scale,
-                          alignment: Alignment.topCenter,
-                          child: _buildCard(context, card, i == _cards.length - 1),
+                  child: _userCards.isEmpty
+                      ? Center(
+                          child: const Text(
+                            '등록된 카드가 없습니다.',
+                            style: TextStyle(color: Colors.black54),
+                          ),
+                        )
+                      : Stack(
+                          clipBehavior: Clip.none,
+                          children: List.generate(_userCards.length, (i) {
+                            final card = _userCards[i];
+                            // Keep all visible cards the same scale/size.
+                            final offset = i * 40.0;
+                            final scale = 1.0;
+                            return Positioned(
+                              top: offset,
+                              left: 0,
+                              right: 0,
+                              child: Transform.scale(
+                                scale: scale,
+                                alignment: Alignment.topCenter,
+                                child: _buildCard(
+                                  context,
+                                  card,
+                                  i == _userCards.length - 1,
+                                ),
+                              ),
+                            );
+                          }),
                         ),
-                      );
-                    }),
-                  ),
                 ),
 
                 const SizedBox(height: 28),
@@ -69,10 +160,8 @@ class CardAnalysisPage extends StatelessWidget {
                 ),
                 const SizedBox(height: 18),
 
-                // Recommendation sections
-                Column(
-                  children: _recommendations.map((section) => _buildRecommendationSection(context, section)).toList(),
-                ),
+                // [수정] 백엔드 추천 카드 데이터 _recommendedCards 사용
+                _buildRecommendedCardsSection(),
               ],
             ),
           ),
@@ -81,51 +170,39 @@ class CardAnalysisPage extends StatelessWidget {
     );
   }
 
-  // Sample recommendation data: category, totalSpent, recommended cards
-  static final List<Map<String, dynamic>> _recommendations = [
-    {
-      'category': '택시',
-      'total': 27133,
-      'items': [
-        {'image': 'assets/cards/card1.png', 'title': '현대카드', 'subtitle': '연회비: 20만 원', 'percent': '110%'},
-        {'image': 'assets/cards/card2.png', 'title': 'BC카드', 'subtitle': '연회비: 20만 원', 'percent': '110%'},
-        {'image': 'assets/cards/card3.png', 'title': '롯데카드', 'subtitle': '연회비: 20만 원', 'percent': '230%'},
-        {'image': 'assets/cards/card4.png', 'title': 'Mr.Life', 'subtitle': '연회비: 20만 원', 'percent': '190%'},
-      ],
-    },
-    {
-      'category': '교통',
-      'total': 7816,
-      'items': [
-        {'image': 'assets/cards/card1.png', 'title': '현대카드', 'subtitle': '연회비: 20만 원', 'percent': 'ROI'},
-        {'image': 'assets/cards/card2.png', 'title': 'BC카드', 'subtitle': '연회비: 20만 원', 'percent': '110%'},
-        {'image': 'assets/cards/card3.png', 'title': '롯데카드', 'subtitle': '연회비: 20만 원', 'percent': '95%'},
-        {'image': 'assets/cards/card4.png', 'title': '신한카드', 'subtitle': '연회비: 20만 원', 'percent': '130%'},
-      ],
-    },
-    {
-      'category': '마트',
-      'total': 4500,
-      'items': [
-        {'image': 'assets/cards/card2.png', 'title': '이마트카드', 'subtitle': '연회비: 10만 원', 'percent': '150%'},
-        {'image': 'assets/cards/card3.png', 'title': '롯데마트카드', 'subtitle': '연회비: 12만 원', 'percent': '140%'},
-        {'image': 'assets/cards/card4.png', 'title': '홈플러스카드', 'subtitle': '연회비: 8만 원', 'percent': '125%'},
-        {'image': 'assets/cards/card1.png', 'title': '쿠팡카드', 'subtitle': '연회비: 0원', 'percent': '115%'},
-      ],
-    },
-  ];
+  // [추가] 추천 카드 섹션 빌드
+  // [설명] 백엔드에서 받아온 추천 카드들을 그리드 레이아웃으로 표시
+  Widget _buildRecommendedCardsSection() {
+    if (_recommendedCards.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.grey[100],
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '추천 카드',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              '더 많은 추천을 받으려면 거래 내역을 기록해 주세요.',
+              style: TextStyle(fontSize: 13, color: Colors.black54),
+            ),
+          ],
+        ),
+      );
+    }
 
-  Widget _buildRecommendationSection(BuildContext context, Map<String, dynamic> section) {
-    final items = section['items'] as List<dynamic>;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(section['category'], style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w700)),
-            Text('총 ${_formatWon(section['total'] as int)} 썼어요', style: const TextStyle(color: Colors.black54)),
-          ],
+        const Text(
+          '추천 카드',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
         ),
         const SizedBox(height: 12),
         GridView.count(
@@ -135,104 +212,144 @@ class CardAnalysisPage extends StatelessWidget {
           mainAxisSpacing: 12,
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
-          children: items.map((it) => _RecommendationCard(data: it as Map<String, dynamic>)).toList(),
+          children: _recommendedCards
+              .map((card) => _RecommendedCardFromBackend(card: card))
+              .toList(),
         ),
-        const SizedBox(height: 28),
       ],
     );
   }
 
+  // [추가] 금액을 원화 형식으로 표시하는 헬퍼 메서드
+  // [설명] 1000단위 쉼표 추가 (예: 123456 → 123,456원)
   String _formatWon(int value) {
     final s = value.toString();
     final out = s.replaceAllMapped(RegExp(r"\B(?=(\d{3})+(?!\d))"), (m) => ',');
     return '${out}원';
   }
 
-  Widget _buildCard(BuildContext context, WalletCard card, bool isBottom) {
+  // [수정] 백엔드 데이터 CreditCard를 받아서 카드 UI 빌드
+  // [설명] WalletCard 대신 CreditCard 사용하여 백엔드 데이터 표시
+  Widget _buildCard(BuildContext context, CreditCard card, bool isBottom) {
     return GestureDetector(
-      onTap: () => Navigator.of(context).push(MaterialPageRoute(builder: (_) => CardDetailPage(card: card))),
+      // [설명] 카드 클릭 시 상세 페이지로 이동 (카드 정보 표시용)
+      onTap: () {
+        // [수정] CardDetailPage를 CreditCard 타입으로 수정
+        Navigator.of(
+          context,
+        ).push(MaterialPageRoute(builder: (_) => CardDetailPage(card: card)));
+      },
       child: Container(
-      height: 160,
-      margin: const EdgeInsets.symmetric(horizontal: 6),
-      decoration: BoxDecoration(
-        color: card.color,
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: [
-          BoxShadow(color: Colors.black.withOpacity(0.08), blurRadius: 12, offset: const Offset(0, 6)),
-        ],
-      ),
-      child: Stack(
-        children: [
-          Positioned(
-            left: 20,
-            top: 20,
-            child: Container(
-              width: 48,
-              height: 34,
-              decoration: BoxDecoration(
-                color: Colors.white.withOpacity(0.6),
-                borderRadius: BorderRadius.circular(6),
+        height: 160,
+        margin: const EdgeInsets.symmetric(horizontal: 6),
+        decoration: BoxDecoration(
+          // [설명] 백엔드에서 제공하는 색상 또는 기본값
+          color: Colors.grey[200],
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.08),
+              blurRadius: 12,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        child: Stack(
+          children: [
+            // [설명] 카드 로고 영역
+            Positioned(
+              left: 20,
+              top: 20,
+              child: CardImageWidget(
+                // [중요] 백엔드에서 받아온 이미지 URL 표시
+                imageUrl: card.imageUrl,
+                width: 48,
+                height: 34,
+                borderRadius: 6,
               ),
             ),
-          ),
-          // optional badge on top-right
-          Positioned(
-            right: 18,
-            top: 18,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-              decoration: BoxDecoration(
-                color: Colors.black.withOpacity(0.75),
-                borderRadius: BorderRadius.circular(16),
-              ),
-              child: Text(card.label, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700, fontSize: 12)),
-            ),
-          ),
-          Positioned(
-            left: 20,
-            bottom: 24,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(card.bankName, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Colors.black87)),
-                const SizedBox(height: 6),
-                Text(card.maskedNumber, style: const TextStyle(fontSize: 12, color: Colors.black54)),
-              ],
-            ),
-          ),
-          if (!isBottom)
-            Positioned.fill(
+            // [설명] 카드 번호 배지 (우상단)
+            Positioned(
+              right: 18,
+              top: 18,
               child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
                 decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  gradient: LinearGradient(
-                    colors: [Colors.white.withOpacity(0.0), Colors.white.withOpacity(0.02)],
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
+                  color: Colors.black.withOpacity(0.75),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Text(
+                  // [설명] 카드 이름 표시
+                  card.name.length > 10
+                      ? '${card.name.substring(0, 10)}...'
+                      : card.name,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                    fontSize: 12,
                   ),
                 ),
               ),
             ),
-        ],
+            // [설명] 카드사 정보 (좌하단)
+            Positioned(
+              left: 20,
+              bottom: 24,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // [설명] 카드사명 표시
+                  Text(
+                    card.company,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.black87,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  // [설명] 연회비 표시
+                  Text(
+                    '연회비: ${_formatWon(card.annualFee)}',
+                    style: const TextStyle(fontSize: 12, color: Colors.black54),
+                  ),
+                ],
+              ),
+            ),
+            // [설명] 카드 그라디언트 오버레이 (맨 위 카드 제외)
+            if (!isBottom)
+              Positioned.fill(
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    gradient: LinearGradient(
+                      colors: [
+                        Colors.white.withOpacity(0.0),
+                        Colors.white.withOpacity(0.02),
+                      ],
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
       ),
-    ),
     );
   }
 }
 
-class WalletCard {
-  final Color color;
-  final String label;
-  final String bankName;
-  final String maskedNumber;
-  final String? imagePath;
+// [추가] 백엔드 추천 카드를 표시하는 위젯
+// [설명] CreditCard 모델을 사용하여 카드 정보와 이미지를 표시
+class _RecommendedCardFromBackend extends StatelessWidget {
+  // [설명] 백엔드에서 받아온 카드 데이터
+  final CreditCard card;
 
-  const WalletCard({this.imagePath, required this.color, required this.label, this.bankName = '카드', this.maskedNumber = ''});
-}
-
-class _RecommendationCard extends StatelessWidget {
-  final Map<String, dynamic> data;
-  const _RecommendationCard({super.key, required this.data});
+  const _RecommendedCardFromBackend({required this.card});
 
   @override
   Widget build(BuildContext context) {
@@ -240,40 +357,72 @@ class _RecommendationCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(14),
-        boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.04), blurRadius: 12, offset: const Offset(0, 6))],
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 12,
+            offset: const Offset(0, 6),
+          ),
+        ],
       ),
       padding: const EdgeInsets.all(12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(10),
-            child: SizedBox(
-              height: 80,
-              width: double.infinity,
-              child: Image.asset(
-                data['image'] as String,
-                fit: BoxFit.cover,
-                errorBuilder: (c, e, s) => Container(
-                  color: Colors.grey.shade200,
-                  child: const Icon(Icons.credit_card, size: 28, color: Colors.black26),
-                ),
-              ),
-            ),
+          // [중요] 백엔드에서 받아온 이미지 URL을 CardImageWidget으로 표시
+          CardImageWidget(
+            imageUrl: card.imageUrl,
+            width: double.infinity,
+            height: 80,
+            borderRadius: 10,
+            fit: BoxFit.cover,
           ),
           const SizedBox(height: 10),
-          Text(data['title'] as String, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700)),
+          // [설명] 카드 이름 표시
+          Text(
+            card.name,
+            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
           const SizedBox(height: 6),
           Row(
             children: [
-              Expanded(child: Text(data['subtitle'] as String, style: const TextStyle(fontSize: 11, color: Colors.black54))),
-              const SizedBox(width: 8),
-              Text(data['percent'] as String, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800, color: Colors.black87)),
+              // [설명] 카드사 및 연회비 정보 표시
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      card.company,
+                      style: const TextStyle(
+                        fontSize: 10,
+                        color: Colors.black54,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    Text(
+                      '연회비: ${_formatWonStatic(card.annualFee)}',
+                      style: const TextStyle(
+                        fontSize: 11,
+                        color: Colors.black54,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ],
           ),
         ],
       ),
     );
   }
-}
 
+  // [추가] 정적 메서드로 금액 포맷팅 (StatelessWidget에서 사용)
+  static String _formatWonStatic(int value) {
+    final s = value.toString();
+    final out = s.replaceAllMapped(RegExp(r"\B(?=(\d{3})+(?!\d))"), (m) => ',');
+    return '${out}원';
+  }
+}

--- a/Frontend/lib/screens/cards/card_detail_page.dart
+++ b/Frontend/lib/screens/cards/card_detail_page.dart
@@ -1,10 +1,12 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'card_analysis_page.dart';
+import 'package:my_app/models/card.dart'; // [추가] CreditCard 모델 import
+import 'package:my_app/widgets/card_image.dart'; // [추가] 카드 이미지 위젯 import
 
+// [수정] CardDetailPage를 CreditCard 타입으로 변경
 class CardDetailPage extends StatelessWidget {
-  final WalletCard card;
+  final CreditCard card; // [수정] WalletCard -> CreditCard
 
   const CardDetailPage({super.key, required this.card});
 
@@ -25,9 +27,18 @@ class CardDetailPage extends StatelessWidget {
               const SizedBox(height: 8),
               Center(child: _buildVerticalCard(context)),
               const SizedBox(height: 10),
-              Text(card.label, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w800)),
+              Text(
+                card.name, // [수정] card.label -> card.name
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
               const SizedBox(height: 6),
-              Text(card.maskedNumber, style: const TextStyle(fontSize: 12, color: Colors.black54)),
+              Text(
+                card.company, // [수정] card.maskedNumber -> card.company
+                style: const TextStyle(fontSize: 12, color: Colors.black54),
+              ),
               const SizedBox(height: 18),
 
               // Month selector
@@ -43,7 +54,13 @@ class CardDetailPage extends StatelessWidget {
                         Text('01월', style: TextStyle(color: Colors.black54)),
                       ],
                     ),
-                    const Text('2025년 02월', style: TextStyle(fontSize: 28, fontWeight: FontWeight.w900)),
+                    const Text(
+                      '2025년 02월',
+                      style: TextStyle(
+                        fontSize: 28,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
                     Row(
                       children: const [
                         Text('03월', style: TextStyle(color: Colors.black54)),
@@ -63,16 +80,29 @@ class CardDetailPage extends StatelessWidget {
                   decoration: BoxDecoration(
                     color: Colors.white,
                     borderRadius: BorderRadius.circular(24),
-                    boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.04), blurRadius: 12, offset: const Offset(0, 6))],
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.04),
+                        blurRadius: 12,
+                        offset: const Offset(0, 6),
+                      ),
+                    ],
                   ),
                   child: Column(
                     children: [
                       const SizedBox(height: 18),
                       // semicircle chart
-                      SemicircleChart(percent: 0.7, received: 23000, total: 33000),
+                      SemicircleChart(
+                        percent: 0.7,
+                        received: 23000,
+                        total: 33000,
+                      ),
                       const SizedBox(height: 12),
                       Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 18.0, vertical: 8),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 18.0,
+                          vertical: 8,
+                        ),
                         child: Column(
                           children: [
                             Row(
@@ -80,12 +110,30 @@ class CardDetailPage extends StatelessWidget {
                               children: [
                                 Row(
                                   children: [
-                                    Container(width: 10, height: 10, decoration: BoxDecoration(shape: BoxShape.circle, color: Color(0xFF15C1D6))),
+                                    Container(
+                                      width: 10,
+                                      height: 10,
+                                      decoration: BoxDecoration(
+                                        shape: BoxShape.circle,
+                                        color: Color(0xFF15C1D6),
+                                      ),
+                                    ),
                                     const SizedBox(width: 8),
-                                    const Text('내가 받은 혜택', style: TextStyle(fontSize: 13, color: Colors.black87)),
+                                    const Text(
+                                      '내가 받은 혜택',
+                                      style: TextStyle(
+                                        fontSize: 13,
+                                        color: Colors.black87,
+                                      ),
+                                    ),
                                   ],
                                 ),
-                                Text(_formatWon(23000), style: const TextStyle(fontWeight: FontWeight.w700)),
+                                Text(
+                                  _formatWon(23000),
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
                               ],
                             ),
                             const SizedBox(height: 10),
@@ -94,12 +142,30 @@ class CardDetailPage extends StatelessWidget {
                               children: [
                                 Row(
                                   children: [
-                                    Container(width: 10, height: 10, decoration: BoxDecoration(shape: BoxShape.circle, color: Color(0xFF8B5CF6))),
+                                    Container(
+                                      width: 10,
+                                      height: 10,
+                                      decoration: BoxDecoration(
+                                        shape: BoxShape.circle,
+                                        color: Color(0xFF8B5CF6),
+                                      ),
+                                    ),
                                     const SizedBox(width: 8),
-                                    const Text('이 카드의 총 혜택', style: TextStyle(fontSize: 13, color: Colors.black87)),
+                                    const Text(
+                                      '이 카드의 총 혜택',
+                                      style: TextStyle(
+                                        fontSize: 13,
+                                        color: Colors.black87,
+                                      ),
+                                    ),
                                   ],
                                 ),
-                                Text(_formatWon(33000), style: const TextStyle(fontWeight: FontWeight.w700)),
+                                Text(
+                                  _formatWon(33000),
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
                               ],
                             ),
                             const SizedBox(height: 18),
@@ -123,15 +189,20 @@ class CardDetailPage extends StatelessWidget {
     final width = MediaQuery.of(context).size.width * 0.5;
     final height = width * 1.6;
 
-    if (card.imagePath != null) {
+    // [수정] CreditCard의 imageUrl을 사용하여 네트워크 이미지 표시
+    if (card.imageUrl != null && card.imageUrl!.isNotEmpty) {
       return ClipRRect(
         borderRadius: BorderRadius.circular(12),
-        child: Image.asset(
-          card.imagePath!,
+        child: Image.network(
+          card.imageUrl!,
           width: width,
           height: height,
           fit: BoxFit.cover,
           errorBuilder: (c, e, s) => _fallbackCard(width, height),
+          loadingBuilder: (c, child, progress) {
+            if (progress == null) return child;
+            return _fallbackCard(width, height);
+          },
         ),
       );
     }
@@ -144,16 +215,32 @@ class CardDetailPage extends StatelessWidget {
       width: width,
       height: height,
       decoration: BoxDecoration(
-        color: card.color,
+        color: const Color(0xFF1E88E5), // [수정] 기본 파란색
         borderRadius: BorderRadius.circular(12),
-        boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.08), blurRadius: 16, offset: const Offset(0, 8))],
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.08),
+            blurRadius: 16,
+            offset: const Offset(0, 8),
+          ),
+        ],
       ),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Icons.credit_card, size: 56, color: Colors.white.withOpacity(0.9)),
+          Icon(
+            Icons.credit_card,
+            size: 56,
+            color: Colors.white.withOpacity(0.9),
+          ),
           const SizedBox(height: 16),
-          Text(card.bankName, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700)),
+          Text(
+            card.company, // [수정] card.bankName -> card.company
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
         ],
       ),
     );
@@ -171,7 +258,12 @@ class SemicircleChart extends StatelessWidget {
   final int received;
   final int total;
 
-  const SemicircleChart({super.key, required this.percent, required this.received, required this.total});
+  const SemicircleChart({
+    super.key,
+    required this.percent,
+    required this.received,
+    required this.total,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -185,14 +277,27 @@ class SemicircleChart extends StatelessWidget {
         children: [
           CustomPaint(
             size: Size(width, height),
-            painter: _SemicirclePainter(percent: percent, background: Colors.grey.shade200, color: const Color(0xFF15C1D6)),
+            painter: _SemicirclePainter(
+              percent: percent,
+              background: Colors.grey.shade200,
+              color: const Color(0xFF15C1D6),
+            ),
           ),
           Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Text('받은 혜택', style: TextStyle(fontSize: 14, color: Colors.black54)),
+              const Text(
+                '받은 혜택',
+                style: TextStyle(fontSize: 14, color: Colors.black54),
+              ),
               const SizedBox(height: 6),
-              Text(_formatWonStatic(received), style: const TextStyle(fontSize: 28, fontWeight: FontWeight.w900)),
+              Text(
+                _formatWonStatic(received),
+                style: const TextStyle(
+                  fontSize: 28,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
             ],
           ),
         ],
@@ -212,7 +317,11 @@ class _SemicirclePainter extends CustomPainter {
   final Color color;
   final Color background;
 
-  _SemicirclePainter({required this.percent, required this.color, required this.background});
+  _SemicirclePainter({
+    required this.percent,
+    required this.color,
+    required this.background,
+  });
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -233,11 +342,23 @@ class _SemicirclePainter extends CustomPainter {
       ..strokeCap = StrokeCap.round;
 
     // draw full semicircle background (180 degrees)
-    canvas.drawArc(Rect.fromCircle(center: center, radius: radius), math.pi, math.pi, false, bgPaint);
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      math.pi,
+      math.pi,
+      false,
+      bgPaint,
+    );
 
     // draw foreground proportional arc from left to right
     final sweep = math.pi * (percent.clamp(0.0, 1.0));
-    canvas.drawArc(Rect.fromCircle(center: center, radius: radius), math.pi, sweep, false, fgPaint);
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      math.pi,
+      sweep,
+      false,
+      fgPaint,
+    );
   }
 
   @override

--- a/Frontend/lib/services/card_service.dart
+++ b/Frontend/lib/services/card_service.dart
@@ -1,13 +1,15 @@
 // lib/services/card_service.dart
+// [설명] 백엔드 카드 API와 통신하는 서비스 클래스
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:my_app/models/user_card.dart';
+import 'package:my_app/models/card.dart';
 import 'package:my_app/services/api_service.dart';
 
 class CardService {
-  static const String baseUrl = ApiService.baseUrl;
+  static final String baseUrl = ApiService.baseUrl;
 
-  // Helper to get headers with token
+  // [설명] 인증 토큰을 포함한 HTTP 헤더 생성 헬퍼 메서드
+  // [용도] API 요청 시 JWT 토큰을 Authorization 헤더에 포함
   Future<Map<String, String>> get _headers async {
     final token = await ApiService.getAccessToken();
     return {
@@ -16,23 +18,85 @@ class CardService {
     };
   }
 
-  // 내 카드 목록 조회
-  Future<List<UserCard>> getMyCards() async {
+  // [설명] 사용자가 등록한 카드 목록 조회
+  // [API 엔드포인트] GET /api/v1/cards/
+  // [백엔드 응답 형식]
+  // {
+  //   "message": "내 카드 목록 조회 성공",
+  //   "cards": [
+  //     {
+  //       "card_id": 1,
+  //       "card_name": "신한Deep Dream 카드",
+  //       "card_image_url": "https://...",  // 백엔드 DB에 저장된 이미지 URL
+  //       "company": "신한카드",
+  //       "card_number": "**** 1234"
+  //     }
+  //   ]
+  // }
+  Future<List<CreditCard>> getMyCards() async {
     final headers = await _headers;
+    // [설명] 백엔드 카드 목록 API 호출
     final response = await http.get(
       Uri.parse('$baseUrl/cards/'),
       headers: headers,
     );
 
+    print('[CardService] getMyCards 응답: ${response.statusCode}');
+    print('[CardService] 응답 본문: ${response.body}');
+
     if (response.statusCode == 200) {
-      final data = json.decode(response.body);
-      return (data['cards'] as List)
-          .map((card) => UserCard.fromJson(card))
-          .toList();
+      try {
+        final data = json.decode(response.body);
+        // [설명] 응답의 'cards' 배열을 CreditCard 객체 리스트로 변환
+        // 각 카드 객체에는 백엔드에서 제공하는 이미지 URL이 포함됨
+        return (data['cards'] as List)
+            .map((card) => CreditCard.fromJson(card))
+            .toList();
+      } catch (e) {
+        print('[CardService] JSON 파싱 에러: $e');
+        throw Exception('카드 데이터 파싱 실패: $e');
+      }
     } else if (response.statusCode == 401) {
+      // [설명] 인증 실패 시 에러 처리
       throw Exception('인증이 필요합니다. 다시 로그인해주세요.');
     } else {
-      throw Exception('카드 목록 조회 실패: ${response.statusCode}');
+      // [설명] 기타 에러 처리
+      throw Exception('카드 목록 조회 실패: ${response.statusCode} - ${response.body}');
+    }
+  }
+
+  // [설명] 추천 카드 목록 조회 (사용자 소비 패턴 기반)
+  // [API 엔드포인트] GET /api/v1/cards/recommend/
+  // [백엔드 응답] 최근 3개월 소비가 많은 카테고리에 혜택이 높은 카드 반환
+  Future<List<CreditCard>> getRecommendedCards() async {
+    final headers = await _headers;
+    final response = await http.get(
+      Uri.parse('$baseUrl/cards/recommend/'),
+      headers: headers,
+    );
+
+    print('[CardService] getRecommendedCards 응답: ${response.statusCode}');
+    print('[CardService] 응답 본문: ${response.body}');
+
+    if (response.statusCode == 200) {
+      try {
+        final data = json.decode(response.body);
+        // [설명] 추천 카드 리스트 파싱 (각 카드에 이미지 URL 포함)
+        return (data['recommended_cards'] as List)
+            .map((card) => CreditCard.fromJson(card))
+            .toList();
+      } catch (e) {
+        print('[CardService] JSON 파싱 에러: $e');
+        throw Exception('추천 카드 데이터 파싱 실패: $e');
+      }
+    } else if (response.statusCode == 401) {
+      throw Exception('인증이 필요합니다. 다시 로그인해주세요.');
+    } else if (response.statusCode == 404) {
+      // [수정] 지출 데이터가 없으면 빈 리스트 반환 (에러 대신)
+      print('[CardService] 지출 데이터가 없어서 추천 카드가 없습니다.');
+      return [];
+    } else {
+      throw Exception('추천 카드 조회 실패: ${response.statusCode} - ${response.body}');
     }
   }
 }

--- a/Frontend/lib/widgets/card_image.dart
+++ b/Frontend/lib/widgets/card_image.dart
@@ -1,0 +1,97 @@
+// [설명] 카드 이미지 표시 위젯
+// [용도] 백엔드에서 제공하는 카드 이미지 URL을 표시하고,
+//       이미지가 없거나 로딩 실패 시 기본 카드 이미지를 표시
+import 'package:flutter/material.dart';
+
+class CardImageWidget extends StatelessWidget {
+  // [설명] 백엔드에서 받아온 카드 이미지 URL (null일 수 있음)
+  final String? imageUrl;
+
+  // [설명] 이미지 위젯의 너비
+  final double? width;
+
+  // [설명] 이미지 위젯의 높이
+  final double? height;
+
+  // [설명] 이미지가 없을 때 표시할 기본 색상 (null이면 회색)
+  final Color? fallbackColor;
+
+  // [설명] 이미지의 모서리 둥글기
+  final double borderRadius;
+
+  // [설명] 이미지 표시 방식 (cover, contain 등)
+  final BoxFit fit;
+
+  const CardImageWidget({
+    super.key,
+    this.imageUrl,
+    this.width,
+    this.height,
+    this.fallbackColor,
+    this.borderRadius = 12.0,
+    this.fit = BoxFit.cover,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // [설명] 이미지 URL이 있고 비어있지 않은 경우
+    if (imageUrl != null && imageUrl!.isNotEmpty) {
+      // [설명] 네트워크 이미지 표시 (백엔드에서 받아온 URL 사용)
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(borderRadius),
+        child: Image.network(
+          imageUrl!,
+          width: width,
+          height: height,
+          fit: fit,
+          // [설명] 이미지 로딩 중에 표시할 위젯 (로딩 인디케이터)
+          loadingBuilder: (context, child, loadingProgress) {
+            if (loadingProgress == null) {
+              // [설명] 이미지 로딩 완료
+              return child;
+            }
+            // [설명] 이미지 로딩 중 - 로딩 인디케이터 표시
+            return Container(
+              width: width,
+              height: height,
+              decoration: BoxDecoration(
+                color: Colors.grey[200],
+                borderRadius: BorderRadius.circular(borderRadius),
+              ),
+              child: const Center(child: CircularProgressIndicator()),
+            );
+          },
+          // [설명] 이미지 로딩 실패 시 표시할 위젯 (기본 카드 이미지)
+          errorBuilder: (context, error, stackTrace) {
+            return _buildFallbackCard();
+          },
+        ),
+      );
+    } else {
+      // [설명] 이미지 URL이 없는 경우 기본 카드 이미지 표시
+      return _buildFallbackCard();
+    }
+  }
+
+  // [설명] 이미지가 없거나 로딩 실패 시 표시할 기본 카드 이미지 위젯
+  // [용도] 백엔드에 이미지 URL이 없거나, 네트워크 오류로 이미지를 불러올 수 없을 때 사용
+  Widget _buildFallbackCard() {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        // [설명] 기본 배경색 (지정된 색상 또는 회색)
+        color: fallbackColor ?? Colors.grey[300],
+        borderRadius: BorderRadius.circular(borderRadius),
+      ),
+      child: Center(
+        child: Icon(
+          // [설명] 카드 아이콘 표시
+          Icons.credit_card,
+          size: (height ?? 100) * 0.4,
+          color: Colors.white.withOpacity(0.7),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Backend: cards/serializers.py에 절대 URL 변환 로직 추가
- Backend: sync_card_images.py로 CSV에서 이미지 URL DB 동기화
- Backend: users/views.py 회원가입 시 테스트 카드 자동 등록
- Frontend: CardService에서 API로 카드 정보 조회
- Frontend: CreditCard 모델에 imageUrl 필드 추가
- Frontend: card_analysis_page에서 백엔드 데이터로 카드 목록 표시
- Frontend: card_detail_page에서 Image.network로 카드 이미지 표시
- Frontend: CardImageWidget으로 이미지 로딩/에러 처리
- Docs: CARD_IMAGE_FEATURE_README.md 작성 (설치 및 실행 가이드)